### PR TITLE
Use brene/slide-transition-detector for OCR backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,12 +14,19 @@ labeler/assets
 *.pyc
 labeler/*.pyc
 script/*.json
+
 *.pem
 *.mp4
 *.pdf
-utility/input.json
 .idea/*
-utility/sshCredentials.js
-scraper/*.json
 
+utility/input.json
+utility/sshCredentials.js
+
+scraper/*.json
 scraper/out
+
+ocr/contents
+ocr/slides
+ocr/unique
+ocr/*.mp4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ocr"]
+	path = ocr
+	url = git@github.com:brene/slide-transition-detector.git


### PR DESCRIPTION
Uses git submodule to include brene/slide-transition-detector as a dependency. 

After git pull, run the following. 

git submodule init
git submodule update